### PR TITLE
WLTS-34 too many versions generated for updates

### DIFF
--- a/charts/ts-translation-service/Chart.yaml
+++ b/charts/ts-translation-service/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for ts-translation-service App
 name: ts-translation-service
 home: https://github.com/hmcts/ts-translation-service
-version: 0.0.5
+version: 0.0.6
 maintainers:
   - name: HMCTS ts team
 dependencies:
   - name: java
     version: 3.7.6
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/translate/controllers/DictionaryControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/translate/controllers/DictionaryControllerIT.java
@@ -55,6 +55,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.translate.model.ControllerConstants.DICTIONARY_URL;
 import static uk.gov.hmcts.reform.translate.model.ControllerConstants.TRANSLATIONS_URL;
+import static uk.gov.hmcts.reform.translate.security.SecurityUtils.LOAD_TRANSLATIONS_ROLE;
+import static uk.gov.hmcts.reform.translate.security.SecurityUtils.MANAGE_TRANSLATIONS_ROLE;
 import static uk.gov.hmcts.reform.translate.security.SecurityUtils.SERVICE_AUTHORIZATION;
 
 public class DictionaryControllerIT extends BaseTest {
@@ -179,7 +181,7 @@ public class DictionaryControllerIT extends BaseTest {
         @Test
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT})
         void shouldTestConcurrentAddToDictionaryViaPutEndpoint() throws Exception {
-            stubUserInfo("manage-translations");
+            stubUserInfo(MANAGE_TRANSLATIONS_ROLE);
             final ExecutorService executorService = Executors.newFixedThreadPool(4);
             try {
                 // GIVEN
@@ -218,36 +220,75 @@ public class DictionaryControllerIT extends BaseTest {
         // manage-translations
         @Test
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT})
-        void shouldReturn201ForPutDictionaryForIdamMUserWithManageTranslationCreateANewRecord() throws Exception {
-            stubUserInfo("manage-translations");
+        void shouldReturn201ForPutDictionaryForIdamUserWithManageTranslationCreateNewRecords() throws Exception {
+
+            // GIVEN
+            stubUserInfo(MANAGE_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
-                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1, 3))))
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(2))))
                 .andExpect(status().is(201))
                 .andReturn();
 
-            val versionResult = assertDictionaryEntityWithTranslationPhrases("english_1");
-            val versionResult1 = assertDictionaryEntityWithTranslationPhrases("english_2");
-            assertEquals(versionResult, versionResult1);
+            // THEN
+            val versionResult1 = assertDictionaryEntityWithTranslationPhrases("english_1");
+            val versionResult2 = assertDictionaryEntityWithTranslationPhrases("english_2");
+            // NB: version numbers should be equal across single upload
+            assertEquals(versionResult1, versionResult2);
         }
 
         @Test
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT, PUT_CREATE_ENGLISH_PHRASES_WITH_TRANSLATIONS_SCRIPT})
-        void shouldReturn201ForPutDictionaryForIdamUserWithManageTranslationUpdateARecord() throws Exception {
-            stubUserInfo("manage-translations");
+        void shouldReturn201ForPutDictionaryForIdamUserWithManageTranslationUpdateExistingRecords() throws Exception {
+
+            // GIVEN
+            stubUserInfo(MANAGE_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
-                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1, 3))))
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(2))))
                 .andExpect(status().is(201))
                 .andReturn();
 
-            val versionResult = assertDictionaryEntityWithTranslationPhrases("english_1");
-            val versionResult1 = assertDictionaryEntityWithTranslationPhrases("english_2");
-            assertEquals(versionResult, versionResult1);
+            // THEN
+            val versionResult1 = assertDictionaryEntityWithTranslationPhrases("english_1");
+            val versionResult2 = assertDictionaryEntityWithTranslationPhrases("english_2");
+            // NB: version numbers should be equal across single upload
+            assertEquals(versionResult1, versionResult2);
+        }
+
+        @Test
+        @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT, PUT_CREATE_ENGLISH_PHRASES_WITH_TRANSLATIONS_SCRIPT})
+        void shouldReturn201ForPutDictionaryForIdamUserWithManageTranslationNewAndUpdatedRecords() throws Exception {
+
+            // GIVEN
+            stubUserInfo(MANAGE_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
+            mockMvc.perform(put(DICTIONARY_URL)
+                                .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
+                                .contentType(APPLICATION_JSON_VALUE)
+                                .content(
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(4))))
+                .andExpect(status().is(201))
+                .andReturn();
+
+            // THEN
+            val versionResult1 = assertDictionaryEntityWithTranslationPhrases("english_1"); // UPDATED (in SQL file)
+            val versionResult2 = assertDictionaryEntityWithTranslationPhrases("english_2"); // UPDATED (in SQL file)
+            val versionResult3 = assertDictionaryEntityWithTranslationPhrases("english_3"); // NEW
+            val versionResult4 = assertDictionaryEntityWithTranslationPhrases("english_4"); // NEW
+            // NB: version numbers should be equal across single upload
+            assertEquals(versionResult1, versionResult2);
+            assertEquals(versionResult2, versionResult3);
+            assertEquals(versionResult3, versionResult4);
         }
 
         // load-translations user
@@ -255,36 +296,47 @@ public class DictionaryControllerIT extends BaseTest {
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT})
         void shouldReturn201ForPutDictionaryForIdamUserWithLoadTranslationNewPhrases() throws Exception {
 
-            stubUserInfo("load-translations");
+            // GIVEN
+            stubUserInfo(LOAD_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(objectMapper.writeValueAsString(
-                                    getDictionaryRequestsWithoutTranslationPhrases(1, 3)))
+                                    getDictionaryRequestsWithoutTranslationPhrases(3)))
                 )
                 .andExpect(status().is(201))
                 .andReturn();
 
+            // THEN
             assertDictionaryEntityWithOutTranslationPhrases("english_1");
             assertDictionaryEntityWithOutTranslationPhrases("english_2");
+            assertDictionaryEntityWithOutTranslationPhrases("english_3");
         }
 
         @Test
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT, PUT_CREATE_ENGLISH_PHRASES_WITH_TRANSLATIONS_SCRIPT})
         void shouldReturn201ForPutDictionaryForIdamUserWithLoadTranslationExistingPhrases() throws Exception {
 
-            stubUserInfo("load-translations");
+            // GIVEN
+            stubUserInfo(LOAD_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
                                     objectMapper.writeValueAsString(
-                                        getDictionaryRequestsWithoutTranslationPhrases(1, 2)))
+                                        getDictionaryRequestsWithoutTranslationPhrases(2)))
                 )
                 .andExpect(status().is(201))
                 .andReturn();
+
+            // THEN
             // No action taken for existing phrases, verify previous translations are preserved.
-            assertDictionaryEntityWithTranslationPhrases("english_1");
+            assertDictionaryEntityWithTranslationPhrases("english_1"); // NO CHANGE (in SQL file)
+            assertDictionaryEntityWithTranslationPhrases("english_2"); // NO CHANGE (in SQL file)
         }
 
         // 400 errors
@@ -292,12 +344,15 @@ public class DictionaryControllerIT extends BaseTest {
         @DisplayName("Incorrect payload: translations not permitted without `manage-translations` role")
         void shouldReturn400ForPutDictionaryForIdamUserWithLoadTranslationWithIncorrectPayLoad() throws Exception {
 
-            stubUserInfo("load-translations");
+            // GIVEN
+            stubUserInfo(LOAD_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtXuiWeb)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
-                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1, 2))))
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1))))
                 .andExpect(status().is(400))
                 .andReturn();
         }
@@ -306,12 +361,15 @@ public class DictionaryControllerIT extends BaseTest {
         @DisplayName("Incorrect payload: translations not permitted for definition store client")
         void shouldReturn400ForPutDictionaryForIdamDefinitionStoreWithIncorrectPayLoad() throws Exception {
 
-            stubUserInfo("load-translations");
+            // GIVEN
+            stubUserInfo(LOAD_TRANSLATIONS_ROLE);
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .header(SERVICE_AUTHORIZATION, serviceJwtDefinition)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
-                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1, 2))))
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1))))
                 .andExpect(status().is(400))
                 .andReturn();
         }
@@ -319,10 +377,12 @@ public class DictionaryControllerIT extends BaseTest {
         @Test
         @Sql(scripts = {DELETE_TRANSLATION_TABLES_SCRIPT})
         void shouldReturn400ForPutDictionaryForNonIdam() throws Exception {
+
+            // WHEN / THEN
             mockMvc.perform(put(DICTIONARY_URL)
                                 .contentType(APPLICATION_JSON_VALUE)
                                 .content(
-                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1, 2))))
+                                    objectMapper.writeValueAsString(getDictionaryRequestsWithTranslationPhrases(1))))
                 .andExpect(status().is(400))
                 .andReturn();
         }
@@ -364,15 +424,15 @@ public class DictionaryControllerIT extends BaseTest {
             );
     }
 
-    private Dictionary getDictionaryRequestsWithTranslationPhrases(int from, int to) {
+    private Dictionary getDictionaryRequestsWithTranslationPhrases(int count) {
         final Map<String, String> expectedMapKeysAndValues = new HashMap<>();
-        IntStream.range(from, to).forEach(i -> expectedMapKeysAndValues.put("english_" + i, "translated_" + i));
+        IntStream.range(1, count + 1).forEach(i -> expectedMapKeysAndValues.put("english_" + i, "translated_" + i));
         return new Dictionary(expectedMapKeysAndValues);
     }
 
-    private Dictionary getDictionaryRequestsWithoutTranslationPhrases(int from, int to) {
+    private Dictionary getDictionaryRequestsWithoutTranslationPhrases(int count) {
         final Map<String, String> expectedMapKeysAndValues = new HashMap<>();
-        IntStream.range(from, to).forEach(i -> expectedMapKeysAndValues.put("english_" + i, null));
+        IntStream.range(1, count + 1).forEach(i -> expectedMapKeysAndValues.put("english_" + i, null));
         return new Dictionary(expectedMapKeysAndValues);
     }
 

--- a/src/integrationTest/resources/sql/put-create-Dictionary_EnglishPhrases.sql
+++ b/src/integrationTest/resources/sql/put-create-Dictionary_EnglishPhrases.sql
@@ -3,7 +3,9 @@ insert into translation_upload values
 
 insert into dictionary values
   (1, 'english_1', 'translated_1', 1);
+insert into dictionary values
+  (2, 'english_2', 'translated_2', 1);
 
 ALTER SEQUENCE translation_version_seq RESTART WITH 2;
-ALTER SEQUENCE dictionary_id_seq RESTART WITH 2;
+ALTER SEQUENCE dictionary_id_seq RESTART WITH 3;
 

--- a/src/main/java/uk/gov/hmcts/reform/translate/service/DictionaryService.java
+++ b/src/main/java/uk/gov/hmcts/reform/translate/service/DictionaryService.java
@@ -111,11 +111,6 @@ public class DictionaryService {
             ? dictionaryMapper.createTranslationUploadEntity(currentUserId)
             : null;
 
-        // if upload entity has been generated save it now as we know we have at least one translation that will use it
-        if (translationUploadEntity != null) {
-            translationUploadRepository.save(translationUploadEntity);
-        }
-
         dictionaryRequest.getTranslations().entrySet()
             .forEach(phrase -> processPhrase(phrase, translationUploadEntity));
     }
@@ -148,6 +143,9 @@ public class DictionaryService {
         if (hasTranslationPhrase(currentPhrase)) {
             dictionaryEntity.setTranslationUpload(translationUploadOptional);
             dictionaryEntity.setTranslationPhrase(currentPhrase.getValue());
+            // if upload entity has been generated save it now as we know
+            // we have at least one translation that will use it
+            translationUploadRepository.save(translationUploadOptional);
             dictionaryRepository.save(dictionaryEntity);
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
@@ -320,8 +320,7 @@ class DictionaryServiceTest {
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryMapper, times(3)).modelToEntityWithTranslationUploadEntity(any(), any());
             verify(dictionaryRepository, times(3)).save(any());
-            // verify only one translation uploaded entity created
-            verify(translationUploadRepository, times(1)).save(any());
+            verify(translationUploadRepository, never()).save(any());
         }
 
         @Test

--- a/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
@@ -341,6 +341,7 @@ class DictionaryServiceTest {
             verify(dictionaryMapper, times(3)).modelToEntityWithoutTranslationPhrase(any());
             verify(dictionaryRepository, times(3)).save(any());
             // verify no translation uploaded entity created as no translations
+            verify(dictionaryMapper, never()).createTranslationUploadEntity(anyString());
             verify(translationUploadRepository, never()).save(any());
         }
 
@@ -387,7 +388,8 @@ class DictionaryServiceTest {
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryRepository, times(0)).save(any());
             // verify no translation uploaded entity created as no translations
-            verify(translationUploadRepository, times(0)).save(any());
+            verify(dictionaryMapper, never()).createTranslationUploadEntity(anyString());
+            verify(translationUploadRepository, never()).save(any());
         }
 
         @Test

--- a/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/translate/service/DictionaryServiceTest.java
@@ -12,12 +12,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import uk.gov.hmcts.reform.translate.ApplicationParams;
 import uk.gov.hmcts.reform.translate.data.DictionaryEntity;
+import uk.gov.hmcts.reform.translate.data.TranslationUploadEntity;
 import uk.gov.hmcts.reform.translate.errorhandling.BadRequestException;
 import uk.gov.hmcts.reform.translate.errorhandling.RequestErrorException;
 import uk.gov.hmcts.reform.translate.errorhandling.RoleMissingException;
 import uk.gov.hmcts.reform.translate.helper.DictionaryMapper;
 import uk.gov.hmcts.reform.translate.model.Dictionary;
 import uk.gov.hmcts.reform.translate.repository.DictionaryRepository;
+import uk.gov.hmcts.reform.translate.repository.TranslationUploadRepository;
 import uk.gov.hmcts.reform.translate.security.SecurityUtils;
 
 import java.util.Arrays;
@@ -38,6 +40,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -52,14 +55,19 @@ class DictionaryServiceTest {
     private static final String CLIENTS2S_TOKEN = "clientS2SToken";
     private static final String DEFINITION_STORE = "definition_store";
     private static final String XUI = "xui";
+
     @Mock
     DictionaryRepository dictionaryRepository;
+
+    @Mock
+    TranslationUploadRepository translationUploadRepository;
 
     @Mock
     Iterable<DictionaryEntity> repositoryResults;
 
     @Mock
     DictionaryMapper dictionaryMapper;
+
     @Mock
     SecurityUtils securityUtils;
 
@@ -298,73 +306,100 @@ class DictionaryServiceTest {
         @Test
         void shouldPutANewDictionaryForUserWithManageTranslationsRole() {
 
-            final Dictionary dictionaryRequest = getDictionaryRequest(1, 4);
+            // GIVEN
+            final Dictionary dictionaryRequest = getDictionaryRequestWithTranslationPhrases(3);
             given(securityUtils.getUserInfo()).willReturn(getUserInfoWithManageTranslationsRole());
             given(securityUtils.hasRole(anyString())).willReturn(true);
+            given(dictionaryMapper.createTranslationUploadEntity(anyString())).willReturn(createUploadEntity());
+
+            // WHEN
             dictionaryService.putDictionary(dictionaryRequest);
 
+            // THEN
             verify(dictionaryRepository, times(3)).findByEnglishPhrase(any());
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryMapper, times(3)).modelToEntityWithTranslationUploadEntity(any(), any());
             verify(dictionaryRepository, times(3)).save(any());
+            // verify only one translation uploaded entity created
+            verify(translationUploadRepository, times(1)).save(any());
         }
 
         @Test
         void shouldPutANewDictionaryForUserWithoutManageTranslationsRole() {
-            final Dictionary dictionaryRequest = getDictionaryRequestWithoutABody(1, 4);
+
+            // GIVEN
+            final Dictionary dictionaryRequest = getDictionaryRequestWithoutTranslationPhrases(3);
             given(securityUtils.getUserInfo()).willReturn(getUserInfoWithManageTranslationsRole());
             given(securityUtils.hasRole(anyString())).willReturn(false);
+
+            // WHEN
             dictionaryService.putDictionary(dictionaryRequest);
 
+            // THEN
             verify(dictionaryRepository, times(3)).findByEnglishPhrase(any());
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryMapper, times(3)).modelToEntityWithoutTranslationPhrase(any());
             verify(dictionaryRepository, times(3)).save(any());
+            // verify no translation uploaded entity created as no translations
+            verify(translationUploadRepository, never()).save(any());
         }
 
         @Test
         void shouldUpdateADictionaryForUserWithManageTranslationsRole() {
 
-            final Dictionary dictionaryRequest = getDictionaryRequest(1, 2);
+            // GIVEN
+            final Dictionary dictionaryRequest = getDictionaryRequestWithTranslationPhrases(1);
             final DictionaryEntity dictionaryEntity =
                 createDictionaryEntity("english_1", "translated_1");
 
             given(dictionaryRepository.findByEnglishPhrase(any())).willReturn(Optional.of(dictionaryEntity));
             given(securityUtils.getUserInfo()).willReturn(getUserInfoWithManageTranslationsRole());
             given(securityUtils.hasRole(anyString())).willReturn(true);
+            given(dictionaryMapper.createTranslationUploadEntity(anyString())).willReturn(createUploadEntity());
+
+            // WHEN
             dictionaryService.putDictionary(dictionaryRequest);
 
+            // THEN
             verify(dictionaryRepository, times(1)).findByEnglishPhrase(any());
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryRepository, times(1)).save(any());
+            verify(translationUploadRepository, times(1)).save(any());
         }
-
 
         @Test
         void shouldUpdateADictionaryForUserWithoutManageTranslationsRole() {
 
-            final Dictionary dictionaryRequest = getDictionaryRequestWithoutABody(1, 2);
+            // GIVEN
+            final Dictionary dictionaryRequest = getDictionaryRequestWithoutTranslationPhrases(1);
             final DictionaryEntity dictionaryEntity =
                 createDictionaryEntity("english_1", "translated_1");
 
             given(dictionaryRepository.findByEnglishPhrase(any())).willReturn(Optional.of(dictionaryEntity));
             given(securityUtils.getUserInfo()).willReturn(getUserInfoWithManageTranslationsRole());
             given(securityUtils.hasRole(anyString())).willReturn(false);
+
+            // WHEN
             dictionaryService.putDictionary(dictionaryRequest);
 
+            // THEN
             verify(dictionaryRepository, times(1)).findByEnglishPhrase(any());
             verify(securityUtils, times(1)).hasRole(anyString());
             verify(dictionaryRepository, times(0)).save(any());
+            // verify no translation uploaded entity created as no translations
+            verify(translationUploadRepository, times(0)).save(any());
         }
-
 
         @Test
         void shouldPutDictionaryRoleCheckForAValidUserWithManageTranslationsRole() {
 
+            // GIVEN
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(XUI);
             given(securityUtils.hasAnyOfTheseRoles(anyList())).willReturn(true);
+
+            // WHEN / THEN
             assertDoesNotThrow(
                 () -> dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN)
             );
@@ -372,10 +407,14 @@ class DictionaryServiceTest {
 
         @Test
         void shouldPutDictionaryRoleCheckForAValidUserWithLoadTranslationRole() {
+
+            // GIVEN
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
             given(securityUtils.hasAnyOfTheseRoles(anyList())).willReturn(true);
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(XUI);
+
+            // WHEN / THEN
             assertDoesNotThrow(
                 () -> dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN)
             );
@@ -384,11 +423,12 @@ class DictionaryServiceTest {
         @Test
         void shouldPutDictionaryRoleCheckForAValidDefinitionStore() {
 
+            // GIVEN
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(DEFINITION_STORE);
 
-            dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN);
+            // WHEN / THEN
             assertDoesNotThrow(
                 () -> dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN)
             );
@@ -397,15 +437,20 @@ class DictionaryServiceTest {
 
         @Test
         void shouldFailPutDictionaryRoleCheckForAValidUserWithOutAnyRole() {
+
+            // GIVEN
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
 
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(XUI);
             given(securityUtils.hasAnyOfTheseRoles(anyList())).willReturn(false);
 
+            // WHEN / THEN
             RequestErrorException roleMissingException = assertThrows(
                 RequestErrorException.class, () -> dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN)
             );
+
+            // THEN
             assertThat(roleMissingException).isInstanceOf(RequestErrorException.class);
             assertEquals(
                 String.format(
@@ -418,15 +463,19 @@ class DictionaryServiceTest {
         @Test
         void shouldFailPutDictionaryDueToInvalidClientToken() {
 
+            // GIVEN
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
 
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(XUI);
             given(securityUtils.hasAnyOfTheseRoles(anyList())).willReturn(false);
 
+            // WHEN / THEN
             RequestErrorException roleMissingException = assertThrows(
                 RequestErrorException.class, () -> dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN)
             );
+
+            // THEN
             assertThat(roleMissingException).isInstanceOf(RequestErrorException.class);
             assertEquals(
                 String.format(
@@ -441,17 +490,20 @@ class DictionaryServiceTest {
         @Test
         void shouldFailUpdateADictionaryForUserWithoutManageTranslationsRoleAndNullPayload() {
 
-
+            // GIVEN
             final Dictionary dictionaryRequest = new Dictionary(null);
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(DEFINITION_STORE);
             given(securityUtils.hasRole(anyString())).willReturn(false);
             dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN);
 
+            // WHEN / THEN
             BadRequestException badRequestException = assertThrows(
                 BadRequestException.class, () -> dictionaryService.putDictionary(dictionaryRequest)
             );
+
+            // THEN
             assertThat(badRequestException).isInstanceOf(BadRequestException.class);
             assertEquals(BAD_SCHEMA, badRequestException.getMessage());
         }
@@ -462,7 +514,7 @@ class DictionaryServiceTest {
 
             final Dictionary dictionaryRequest = new Dictionary(new HashMap<>());
             given(applicationParams.getPutDictionaryS2sServicesBypassRoleAuthCheck())
-                .willReturn(Arrays.asList(DEFINITION_STORE));
+                .willReturn(List.of(DEFINITION_STORE));
             given(securityUtils.getServiceNameFromS2SToken(CLIENTS2S_TOKEN)).willReturn(DEFINITION_STORE);
             given(securityUtils.hasRole(anyString())).willReturn(false);
             dictionaryService.putDictionaryRoleCheck(CLIENTS2S_TOKEN);
@@ -470,6 +522,7 @@ class DictionaryServiceTest {
             BadRequestException badRequestException = assertThrows(
                 BadRequestException.class, () -> dictionaryService.putDictionary(dictionaryRequest)
             );
+
             assertThat(badRequestException).isInstanceOf(BadRequestException.class);
             assertEquals(BAD_SCHEMA, badRequestException.getMessage());
         }
@@ -477,32 +530,34 @@ class DictionaryServiceTest {
         @Test
         void shouldFailUpdateADictionaryForDefinitionStoreWithIncorrectPayload() {
 
-            final Dictionary dictionaryRequest = getDictionaryRequest(1, 2);
+            // GIVEN
+            final Dictionary dictionaryRequest = getDictionaryRequestWithTranslationPhrases(1);
             given(securityUtils.hasRole(anyString())).willReturn(false);
 
+            // WHEN / THEN
             BadRequestException badRequestException = assertThrows(
                 BadRequestException.class, () -> dictionaryService.putDictionary(dictionaryRequest)
             );
+
+            // THEN
             assertThat(badRequestException).isInstanceOf(BadRequestException.class);
             assertEquals(WELSH_NOT_ALLOWED, badRequestException.getMessage());
         }
 
-
-        private Dictionary getDictionaryRequest(int from, int to) {
+        private Dictionary getDictionaryRequestWithTranslationPhrases(int count) {
             final Map<String, String> expectedMapKeysAndValues = new HashMap<>();
-            IntStream.range(from, to).forEach(i -> expectedMapKeysAndValues.put("english_" + i, "translated_" + i));
+            IntStream.range(1, count + 1).forEach(i -> expectedMapKeysAndValues.put("english_" + i, "translated_" + i));
             return new Dictionary(expectedMapKeysAndValues);
         }
 
-        private Dictionary getDictionaryRequestWithoutABody(int from, int to) {
+        private Dictionary getDictionaryRequestWithoutTranslationPhrases(int count) {
             final Map<String, String> expectedMapKeysAndValues = new HashMap<>();
-            IntStream.range(from, to).forEach(i -> expectedMapKeysAndValues.put("english_" + i, null));
+            IntStream.range(1, count + 1).forEach(i -> expectedMapKeysAndValues.put("english_" + i, null));
             return new Dictionary(expectedMapKeysAndValues);
         }
-
 
         private UserInfo getUserInfoWithManageTranslationsRole() {
-            UserInfo userInfo = UserInfo.builder()
+            return UserInfo.builder()
                 .familyName("NE_NU_NE")
                 .name("PEPE")
                 .givenName("givenName")
@@ -510,7 +565,6 @@ class DictionaryServiceTest {
                 .roles(Arrays.asList("ROLE", "manage-translations"))
                 .sub("sub")
                 .build();
-            return userInfo;
         }
     }
 
@@ -520,5 +574,12 @@ class DictionaryServiceTest {
         dictionaryEntity.setTranslationPhrase(translationPhrase);
         return dictionaryEntity;
     }
+
+    private TranslationUploadEntity createUploadEntity() {
+        final var translationUploadEntity = new TranslationUploadEntity();
+        translationUploadEntity.setVersion(123L);
+        return translationUploadEntity;
+    }
+
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [WLTS-34](https://tools.hmcts.net/jira/browse/WLTS-34) _"PUT /dictionary - Updating translations in a single transaction creates multiple versions"_

### Change description ###

Multiple translation updates submitted in a single upload should all use the same upload record.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
