### PR TITLE
WLTS-59: removed suppression for CVE-2021-37533

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,8 +5,10 @@
   <suppress>
     <notes>False Positives
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/WLTS-35
+      CVE-2021-37533 refer https://tools.hmcts.net/jira/browse/WLTS-59
     </notes>
     <cve>CVE-2016-1000027</cve>
+    <cve>CVE-2021-37533</cve>
   </suppress>
   <!--End of false positives section -->
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,11 +11,7 @@
   <!--End of false positives section -->
 
   <!--Please add all the temporary suppression under the below section-->
-  <suppress>
-    <notes>Temporary Suppression
-      CVE-2021-37533 refer https://tools.hmcts.net/jira/browse/WLTS-59</notes>
-    <cve>CVE-2021-37533</cve>
-  </suppress>
+
   <!--End of temporary suppression section -->
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/WLTS-59

### Change description ###

removed suppression for CVE-2021-37533, no longer appears as a dependency check failure

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
