### PR TITLE
CCD-5160 : Fix CVE-2023-35116 : bumped jackson.version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
 ext['spring-security.version'] = '5.8.5'
 ext['spring-framework.version'] = '5.3.27'
 ext['snakeyaml.version'] = '2.0'
-ext['jackson.version'] = '2.15.3'
+ext['jackson.version'] = '2.16.0'
 
 configurations {
   functionalTestImplementation.extendsFrom testImplementation

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -4,8 +4,6 @@
         CVE-2022-45688 refer [Ticket]
         CVE-2022-45047 refer [Ticket]
         CVE-2023-34981 refer [Ticket]
-        CVE-2023-34035 refer [Ticket]
-        CVE-2023-20873 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
@@ -17,10 +15,9 @@
         CVE-2023-33202 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
         CVE-2023-48795 refer [Ticket]
-        CVE-2023-34042 refer [Ticket]</notes>
+        CVE-2023-34042 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-45047</cve>
     <cve>CVE-2023-34981</cve>
@@ -35,7 +32,6 @@
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-48795</cve>
     <cve>CVE-2023-34042</cve>
   </suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5160
Fix CVE-2023-35116 : bumped jackson.version to 2.16.0



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
