### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,7 +312,7 @@ dependencyManagement {
   dependencies {
     dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.70'
 
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.74') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.82') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,41 +2,26 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2022-45688 refer [Ticket]
-        CVE-2022-45047 refer [Ticket]
-        CVE-2023-34981 refer [Ticket]
-        CVE-2023-34035 refer [Ticket]
-        CVE-2023-20873 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-42794 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-5072  refer [Ticket]
-        CVE-2023-4759 refer [Ticket]
-        CVE-2023-35887 refer [Ticket]
+        CVE-2023-5072 refer [Ticket]
         CVE-2023-33202 refer [Ticket]
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
+        CVE-2023-4759 refer [Ticket]
+        CVE-2023-34055 refer [Ticket]
+        CVE-2023-34042 refer [Ticket]
+        CVE-2022-45047 refer [Ticket]
         CVE-2023-48795 refer [Ticket]
-        CVE-2023-34042 refer [Ticket]</notes>
+        CVE-2023-35887 refer [Ticket]
+        CVE-2023-46589 refer [Ticket]</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2022-45047</cve>
-    <cve>CVE-2023-34981</cve>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-5072</cve>
-    <cve>CVE-2023-4759</cve>
-    <cve>CVE-2023-35887</cve>
     <cve>CVE-2023-33202</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-48795</cve>
+    <cve>CVE-2023-4759</cve>
+    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-34042</cve>
+    <cve>CVE-2022-45047</cve>
+    <cve>CVE-2023-48795</cve>
+    <cve>CVE-2023-35887</cve>
+    <cve>CVE-2023-46589</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
