### PR TITLE
CCD-8069 Update missing TS translation endpoint tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Keep the ACR build context limited to files copied by the Dockerfile.
 **
+!acb.yaml
 !Dockerfile
 !lib/
 !lib/applicationinsights.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Keep the ACR build context limited to files copied by the Dockerfile.
+**
+!Dockerfile
+!lib/
+!lib/applicationinsights.json
+!build/
+!build/libs/
+!build/libs/ts-translation-service.jar

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lib/applicationinsights.log
 
 /BEFTA Report for Smoke Tests/
 /BEFTA Report for Functional Tests/
+reports/

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -2,14 +2,10 @@
 
 @Library("Infrastructure@2.4.0")
 
-import uk.gov.hmcts.contino.GradleBuilder
-
 def type = "java"
 def product = "ts"
 def component = "translation-service"
 def branchesToSync = ['demo', 'ithc', 'perftest']
-
-GradleBuilder builder = new GradleBuilder(this, product)
 
 def secrets = [
   'rpx-${env}': [
@@ -65,8 +61,6 @@ def vaultOverrides = [
 
 withPipeline(type, product, component) {
   afterAlways('test') {
-    builder.gradle('integration')
-
     // hmcts/cnp-jenkins-library may fail to copy artifacts after checkstyle error so repeat command (see /src/uk/gov/hmcts/contino/GradleBuilder.groovy)
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/checkstyle/*.html'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/pmd/*.html'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.0")
+@Library("Infrastructure@2.4.9")
 
 def type = "java"
 def product = "ts"

--- a/src/integrationTest/java/uk/gov/hmcts/reform/translate/controllers/OperationalEndpointsIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/translate/controllers/OperationalEndpointsIT.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.translate.controllers;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.translate.BaseTest;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class OperationalEndpointsIT extends BaseTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void stubServiceAuthHealth() {
+        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/s2s/health"))
+                             .willReturn(WireMock.okJson("{\"status\":\"UP\"}")));
+    }
+
+    @Test
+    @DisplayName("Health endpoint reports the application is up")
+    void shouldReportApplicationHealth() throws Exception {
+        mockMvc.perform(get("/health"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+            .andExpect(jsonPath("$.status").value("UP"))
+            .andExpect(jsonPath("$.groups").isArray());
+    }
+
+    @Test
+    @DisplayName("Liveness endpoint reports the application is alive")
+    void shouldReportApplicationLiveness() throws Exception {
+        mockMvc.perform(get("/health/liveness"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+            .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    @DisplayName("Readiness endpoint reports the application is ready")
+    void shouldReportApplicationReadiness() throws Exception {
+        mockMvc.perform(get("/health/readiness"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"))
+            .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    @DisplayName("Info endpoint returns actuator information")
+    void shouldReturnApplicationInfo() throws Exception {
+        mockMvc.perform(get("/info"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/vnd.spring-boot.actuator.v3+json"));
+    }
+
+    @Test
+    @DisplayName("Swagger UI endpoint serves the documentation page")
+    void shouldServeSwaggerUi() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith("text/html"))
+            .andExpect(content().string(org.hamcrest.Matchers.containsString("Swagger UI")));
+    }
+
+    @Test
+    @DisplayName("OpenAPI endpoint serves the live API specification")
+    void shouldServeOpenApiSpecification() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith("application/json"))
+            .andExpect(jsonPath("$.openapi", startsWith("3.")))
+            .andExpect(jsonPath("$.info.title").value("Welsh Language Translation Service"))
+            .andExpect(jsonPath("$.paths", hasKey("/dictionary")))
+            .andExpect(jsonPath("$.paths", hasKey("/translation/cy")));
+    }
+}


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-8069

### Change description ###
Adds six integration test scenarios for operational and API documentation endpoints:
GET /health
GET /health/liveness
GET /health/readiness
GET /info
GET /swagger-ui/index.html
GET /v3/api-docs
The tests verify successful responses, expected content types, health status, Swagger UI content, and key OpenAPI metadata and paths. The service-auth health dependency is stubbed to keep the aggregate health test deterministic.

### Testing ###
Focused integration test suite passes: 6 tests
Integration-test Checkstyle passes
git diff --check passes


**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
